### PR TITLE
Split Course into Course and Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ python src/run.py
 }
 ```
 
-### /api/courses/track • POST
+### /api/sections/track • POST
 **Headers:**
 ```json
 {
@@ -147,7 +147,7 @@ python src/run.py
 }
 ```
 
-### /api/courses/untrack • POST
+### /api/sections/untrack • POST
 **Headers:**
 ```json
 {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aspy.yaml==1.3.0
 beautifulsoup4==4.8.1
-bs4==0.0.1
+black
 cachetools==4.0.0
 certifi==2019.9.11
 cfgv==2.0.1

--- a/src/app/coursegrab/__init__.py
+++ b/src/app/coursegrab/__init__.py
@@ -1,4 +1,5 @@
 from flask import Blueprint
+from app.coursegrab.controllers.add_courses_controller import *
 from app.coursegrab.controllers.hello_world_controller import *
 from app.coursegrab.controllers.initialize_session_controller import *
 from app.coursegrab.controllers.retrieve_tracking_controller import *
@@ -10,6 +11,7 @@ from app.coursegrab.controllers.update_session_controller import *
 coursegrab = Blueprint("coursegrab", __name__, url_prefix="/api")
 
 controllers = [
+    AddCoursesController(),
     HelloWorldController(),
     InitializeSessionController(),
     RetrieveTrackingController(),

--- a/src/app/coursegrab/__init__.py
+++ b/src/app/coursegrab/__init__.py
@@ -2,8 +2,8 @@ from flask import Blueprint
 from app.coursegrab.controllers.hello_world_controller import *
 from app.coursegrab.controllers.initialize_session_controller import *
 from app.coursegrab.controllers.retrieve_tracking_controller import *
-from app.coursegrab.controllers.track_course_controller import *
-from app.coursegrab.controllers.untrack_course_controller import *
+from app.coursegrab.controllers.track_section_controller import *
+from app.coursegrab.controllers.untrack_section_controller import *
 from app.coursegrab.controllers.update_session_controller import *
 
 # CourseGrab Blueprint
@@ -13,8 +13,8 @@ controllers = [
     HelloWorldController(),
     InitializeSessionController(),
     RetrieveTrackingController(),
-    TrackCourseController(),
-    UntrackCourseController(),
+    TrackSectionController(),
+    UntrackSectionController(),
     UpdateSessionController(),
 ]
 

--- a/src/app/coursegrab/controllers/__init__.py
+++ b/src/app/coursegrab/controllers/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from flask import request
-from app.coursegrab.dao import courses_dao, users_dao
+from app.coursegrab.dao import courses_dao, sections_dao, users_dao
 from app.coursegrab.utils.appdev_controller import AppDevController
 from app.coursegrab.utils.appdev_redirect_controller import AppDevRedirectController
 from app.coursegrab.utils.authorize import authorize_user, extract_bearer

--- a/src/app/coursegrab/controllers/add_courses_controller.py
+++ b/src/app/coursegrab/controllers/add_courses_controller.py
@@ -11,6 +11,7 @@ class AddCoursesController(AppDevController):
 
     @authorize_user
     def content(self, **kwargs):
+        # TODO: Change to scrape classes and their corresponding sections
         courses = scraper.scrape_classes()
         courses = courses_dao.create_courses(courses)
         return [course.serialize() for course in courses]

--- a/src/app/coursegrab/controllers/add_courses_controller.py
+++ b/src/app/coursegrab/controllers/add_courses_controller.py
@@ -11,7 +11,6 @@ class AddCoursesController(AppDevController):
 
     @authorize_user
     def content(self, **kwargs):
-        # TODO: Change to scrape classes and their corresponding sections
-        courses = scraper.scrape_classes()
-        courses = courses_dao.create_courses(courses)
-        return [course.serialize() for course in courses]
+        catalog_tuples = scraper.scrape_classes()
+        for course, sections in catalog_tuples:
+            sections_dao.create_sections(course, sections)

--- a/src/app/coursegrab/controllers/retrieve_tracking_controller.py
+++ b/src/app/coursegrab/controllers/retrieve_tracking_controller.py
@@ -11,5 +11,5 @@ class RetrieveTrackingController(AppDevController):
     @authorize_user
     def content(self, **kwargs):
         user = kwargs.get("user")
-        courses = users_dao.get_tracked_courses(user.id)
-        return [course.serialize() for course in courses]
+        sections = users_dao.get_tracked_sections(user.id)
+        return [section.serialize() for section in sections]

--- a/src/app/coursegrab/controllers/track_section_controller.py
+++ b/src/app/coursegrab/controllers/track_section_controller.py
@@ -1,9 +1,9 @@
 from . import *
 
 
-class TrackCourseController(AppDevController):
+class TrackSectionController(AppDevController):
     def get_path(self):
-        return "/courses/track/"
+        return "/sections/track/"
 
     def get_methods(self):
         return ["POST"]
@@ -16,5 +16,5 @@ class TrackCourseController(AppDevController):
         if not catalog_num:
             raise Exception("Must provide catalog number.")
 
-        course = users_dao.track_course(user.id, catalog_num)
-        return course.serialize()
+        section = users_dao.track_section(user.id, catalog_num)
+        return section.serialize()

--- a/src/app/coursegrab/controllers/untrack_section_controller.py
+++ b/src/app/coursegrab/controllers/untrack_section_controller.py
@@ -1,9 +1,9 @@
 from . import *
 
 
-class UntrackCourseController(AppDevController):
+class UntrackSectionController(AppDevController):
     def get_path(self):
-        return "/courses/untrack/"
+        return "/sections/untrack/"
 
     def get_methods(self):
         return ["POST"]
@@ -16,5 +16,5 @@ class UntrackCourseController(AppDevController):
         if not catalog_num:
             raise Exception("Must provide catalog number.")
 
-        course = users_dao.untrack_course(user.id, catalog_num)
-        return course.serialize()
+        section = users_dao.untrack_section(user.id, catalog_num)
+        return section.serialize()

--- a/src/app/coursegrab/dao/__init__.py
+++ b/src/app/coursegrab/dao/__init__.py
@@ -2,4 +2,5 @@
 from app import db
 
 from app.coursegrab.models.course import Course
+from app.coursegrab.models.section import Section
 from app.coursegrab.models.user import User

--- a/src/app/coursegrab/dao/courses_dao.py
+++ b/src/app/coursegrab/dao/courses_dao.py
@@ -2,11 +2,12 @@ from . import *
 
 
 def get_course_by_subject_and_course_num(subject_code, course_num):
-    return Course.query.filter_by(subject_code=subject_code).filter_by(course_num=course_num).first()
+    return Course.query.filter_by(subject_code=subject_code, course_num=course_num).first()
 
 
 def create_course(subject_code, course_num, title):
     optional_course = get_course_by_subject_and_course_num(subject_code, course_num)
+
     if optional_course:
         return optional_course
 

--- a/src/app/coursegrab/dao/courses_dao.py
+++ b/src/app/coursegrab/dao/courses_dao.py
@@ -1,24 +1,16 @@
 from . import *
 
 
-def get_course_by_catalog_num(catalog_num):
-    return Course.query.get(catalog_num)
+def get_course_by_subject_and_course_num(subject_code, course_num):
+    return Course.query.filter_by(subject_code=subject_code).filter_by(course_num=course_num).first()
 
 
-def get_subject_by_catalog_num(catalog_num):
-    course = get_course_by_catalog_num(catalog_num)
-    if not course:
-        raise Exception("Catalog number is invalid.")
-    return course.subject_code
+def create_course(subject_code, course_num, title):
+    optional_course = get_course_by_subject_and_course_num(subject_code, course_num)
+    if optional_course:
+        return optional_course
 
-
-def create_courses(course_lst):
-    courses = []
-    for (subject_code, course_num, title, catalog_num, section) in course_lst:
-        course = Course(
-            subject_code=subject_code, course_num=course_num, title=title, catalog_num=catalog_num, section=section
-        )
-        db.session.add(course)
-        courses.append(course)
+    course = Course(subject_code=subject_code, course_num=course_num, title=title)
+    db.session.add(course)
     db.session.commit()
-    return courses
+    return course

--- a/src/app/coursegrab/dao/sections_dao.py
+++ b/src/app/coursegrab/dao/sections_dao.py
@@ -1,0 +1,23 @@
+from . import *
+
+
+def get_section_by_catalog_num(catalog_num):
+    return Section.query.get(catalog_num)
+
+
+def create_sections(course, section_lst):
+    sections = []
+    (subject_code, course_num, title) = course
+    course_id = courses_dao.create_course(subject_code, course_num, title).id
+
+    for (catalog_num, section) in section_lst:
+        optional_section = get_section_by_catalog_num(catalog_num)
+
+        if optional_section:
+            sections.append(optional_section)
+        else:
+            section = Section(catalog_num=catalog_num, section=section, course_id=course_id)
+            sections.append(section)
+            db.session.add(section)
+    db.session.commit()
+    return sections

--- a/src/app/coursegrab/dao/sections_dao.py
+++ b/src/app/coursegrab/dao/sections_dao.py
@@ -10,13 +10,13 @@ def create_sections(course, section_lst):
     (subject_code, course_num, title) = course
     course_id = courses_dao.create_course(subject_code, course_num, title).id
 
-    for (catalog_num, section) in section_lst:
+    for (catalog_num, section, status) in section_lst:
         optional_section = get_section_by_catalog_num(catalog_num)
 
         if optional_section:
             sections.append(optional_section)
         else:
-            section = Section(catalog_num=catalog_num, section=section, course_id=course_id)
+            section = Section(catalog_num=catalog_num, section=section, status=status, course_id=course_id)
             sections.append(section)
             db.session.add(section)
     db.session.commit()

--- a/src/app/coursegrab/dao/users_dao.py
+++ b/src/app/coursegrab/dao/users_dao.py
@@ -10,8 +10,8 @@ def get_user_by_email(email):
     return User.query.filter(User.email == email).first()
 
 
-def get_tracked_courses(user_id):
-    return get_user_by_id(user_id).courses
+def get_tracked_sections(user_id):
+    return get_user_by_id(user_id).sections
 
 
 def create_user(email, first_name, last_name):
@@ -40,27 +40,27 @@ def refresh_session(update_token):
     return user
 
 
-def track_course(user_id, catalog_num):
+def track_section(user_id, catalog_num):
     user = get_user_by_id(user_id)
-    course = courses_dao.get_course_by_catalog_num(catalog_num)
-    if not course:
+    section = sections_dao.get_section_by_catalog_num(catalog_num)
+    if not section:
         raise Exception("Catalog number is not valid.")
-    if course in user.courses:
-        raise Exception("You are already tracking this course.")
+    if section in user.sections:
+        raise Exception("You are already tracking this section.")
 
-    user.courses.append(course)
+    user.sections.append(section)
     db.session.commit()
-    return course
+    return section
 
 
-def untrack_course(user_id, catalog_num):
+def untrack_section(user_id, catalog_num):
     user = get_user_by_id(user_id)
-    course = courses_dao.get_course_by_catalog_num(catalog_num)
-    if not course:
+    section = sections_dao.get_section_by_catalog_num(catalog_num)
+    if not section:
         raise Exception("Catalog number is not valid.")
-    if course not in user.courses:
-        raise Exception("You aren't tracking this course.")
+    if section not in user.sections:
+        raise Exception("You aren't tracking this section.")
 
-    user.courses.remove(course)
+    user.sections.remove(section)
     db.session.commit()
-    return course
+    return section

--- a/src/app/coursegrab/models/course.py
+++ b/src/app/coursegrab/models/course.py
@@ -1,31 +1,23 @@
 from app import db
-from app.coursegrab.utils import scraper
 
 
 class Course(db.Model):
     __tablename__ = "courses"
-    catalog_num = db.Column(db.Integer, primary_key=True)
+    id = db.Column(db.Integer, primary_key=True)
     subject_code = db.Column(db.String, nullable=False)
     course_num = db.Column(db.Integer, nullable=False)
     title = db.Column(db.String, nullable=False)
-    section = db.Column(db.String, nullable=False)
+    sections = db.relationship("Section", cascade="delete")
 
     def __init__(self, **kwargs):
-        self.catalog_num = kwargs.get("catalog_num")
         self.subject_code = kwargs.get("subject_code")
         self.course_num = kwargs.get("course_num")
         self.title = kwargs.get("title")
-        self.section = kwargs.get("section")
 
     def serialize(self):
         return {
-            "catalog_num": self.catalog_num,
             "subject_code": self.subject_code,
             "course_num": self.course_num,
             "title": self.title,
-            "section": self.section,
-            "status": self.get_course_status(),
+            "sections": [section.serialize() for section in self.sections],
         }
-
-    def get_course_status(self):
-        return scraper.get_course_status(self.subject_code, self.catalog_num)

--- a/src/app/coursegrab/models/section.py
+++ b/src/app/coursegrab/models/section.py
@@ -1,0 +1,27 @@
+from app import db
+from app.coursegrab.models.course import Course
+
+
+class Section(db.Model):
+    __tablename__ = "sections"
+    catalog_num = db.Column(db.Integer, primary_key=True)
+    section = db.Column(db.String, nullable=False)
+    status = db.Column(db.String, nullable=False)
+    course_id = db.Column(db.Integer, db.ForeignKey("courses.id"), nullable=False)
+
+    def __init__(self, **kwargs):
+        self.catalog_num = kwargs.get("catalog_num")
+        self.section = kwargs.get("section")
+        self.status = kwargs.get("status")
+        self.course_id = kwargs.get("course_id")
+
+    def serialize(self):
+        course = Course.query.filter_by(id=self.course_id).first()
+        return {
+            "catalog_num": self.catalog_num,
+            "subject_code": course.subject_code,
+            "course_num": course.course_num,
+            "title": course.title,
+            "section": self.section,
+            "status": self.status,
+        }

--- a/src/app/coursegrab/models/user.py
+++ b/src/app/coursegrab/models/user.py
@@ -4,10 +4,10 @@ import os
 from app import db
 
 
-users_to_courses = db.Table(
+users_to_sections = db.Table(
     "users_to_courses",
     db.Column("user_id", db.Integer, db.ForeignKey("users.id")),
-    db.Column("course_id", db.Integer, db.ForeignKey("courses.catalog_num")),
+    db.Column("section_id", db.Integer, db.ForeignKey("sections.catalog_num")),
 )
 
 
@@ -22,7 +22,7 @@ class User(db.Model):
     session_expiration = db.Column(db.DateTime, nullable=False)
     update_token = db.Column(db.String, nullable=False, unique=True)
 
-    courses = db.relationship("Course", secondary=users_to_courses, backref="users")
+    sections = db.relationship("Section", secondary=users_to_sections, backref="users")
 
     def __init__(self, **kwargs):
         self.email = kwargs.get("email")


### PR DESCRIPTION
## Overview
It makes sense to split the current Course model into a Course and Section model. For example, CS 2110 would be a course with multiple Section objects. Each section object belongs to a course and contains info such as the catalog number and section info (time, days).

Addresses #19 and #17 

## Changes Made
- Created Course and Section model
- Edited User model to have relationship with Section
- Edited Course DAO and User DAO
- Created Section DAO
- Changed TrackCourseController and UntrackCourseController to use new models / daos

## Test Coverage
I tested by hitting endpoints locally with Postman and made sure the track/untrack sections worked along with retrieving all tracked sections.

## Screenshots
<details>
<summary>New Schema</summary>

<img width="439" alt="Screen Shot 2020-02-05 at 8 36 20 PM" src="https://user-images.githubusercontent.com/22579863/73898396-36fb1280-4857-11ea-8c40-6807a73155ff.png">

</details>
