### PR TITLE
Change session_expiration format to Unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python src/run.py
 {
   "success": true,
   "data": {
-    "session_expiration": "Tue, 04 Feb 2020 15:22:03 GMT",
+    "session_expiration": "1581435566",
     "session_token": "3c9e0ee538eaa570b7bc0847f18eab66703cc41f",
     "update_token": "d9c3427bd6537131a5d0e8c8fa1d59e764644c2c"
   }
@@ -80,7 +80,7 @@ python src/run.py
 {
   "success": true,
   "data": {
-    "session_expiration": "Tue, 04 Feb 2020 15:22:03 GMT",
+    "session_expiration": "1581435566",
     "session_token": "3c9e0ee538eaa570b7bc0847f18eab66703cc41f",
     "update_token": "d9c3427bd6537131a5d0e8c8fa1d59e764644c2c"
   }

--- a/src/app/coursegrab/models/user.py
+++ b/src/app/coursegrab/models/user.py
@@ -45,6 +45,6 @@ class User(db.Model):
             "first_name": self.first_name,
             "last_name": self.last_name,
             "session_token": self.session_token,
-            "session_expiration": self.session_expiration,
+            "session_expiration": round(self.session_expiration.timestamp()),
             "update_token": self.update_token,
         }


### PR DESCRIPTION
## Overview
The original format of this field was very verbose and hard to parse. After talking to iOS, we decided that a Unix timestamp is a better format.

Addresses #20 

## Changes Made
- Change the serialize method to return the timestamp format
- Update example response in README


## Test Coverage
Tested locally