### PR TITLE
Add support for Android with Google OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ pip install -r requirements.txt
 It's recommended to use [`direnv`](https://direnv.net).
 The required environment variables for this API are the following:
 ```bash
-export CLIENT_ID=""
+export ANDROID_CLIENT_ID=""
+export IOS_CLIENT_ID=""
 export DB_FILENAME=""
 export PORT=5000
 ```
@@ -53,7 +54,8 @@ python src/run.py
 **Body:**
 ```json
 {
-  "token": "<TOKEN received from Google>"
+  "token": "<TOKEN received from Google>",
+  "is_ios": true
 }
 ```
 **Example Response:**

--- a/envrc.template
+++ b/envrc.template
@@ -1,3 +1,4 @@
-export CLIENT_ID=""
+export ANDROID_CLIENT_ID=""
+export IOS_CLIENT_ID=""
 export DB_FILENAME=""
 export PORT=5000

--- a/src/app/coursegrab/controllers/initialize_session_controller.py
+++ b/src/app/coursegrab/controllers/initialize_session_controller.py
@@ -14,8 +14,10 @@ class InitializeSessionController(AppDevController):
     def content(self, **kwargs):
         data = request.get_json()
         token = data.get("token")
+        is_ios = data.get("is_ios")
         try:
-            id_info = id_token.verify_oauth2_token(token, requests.Request(), environ["CLIENT_ID"])
+            client_id = environ["IOS_CLIENT_ID"] if is_ios else environ["ANDROID_CLIENT_ID"]
+            id_info = id_token.verify_oauth2_token(token, requests.Request(), client_id)
 
             if id_info["iss"] not in ["accounts.google.com", "https://accounts.google.com"]:
                 raise ValueError("Wrong issuer.")


### PR DESCRIPTION
## Overview
Android and iOS use different client ids for Google OAuth and before we only were concerned with iOS. This PR adds support for both devices when logging in with Google.

## Changes Made
- Add new `env` var for Android's client id
- Update README and envrc template with new changes
- Edit the `/session/initialize/` endpoint to require client to send their device type so we can use the correct client id

## Test Coverage
I tested as much as I could locally but will have to get @kevinsun-dev verify that it works after deploying to our dev server


