### PR TITLE
Fix session_expiration field and correct spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ python src/run.py
 }
 ```
 
-### /api/users/tracking • GET
+### /api/users/tracking/ • GET
 **Headers:**
 ```json
 {
@@ -121,7 +121,7 @@ python src/run.py
 }
 ```
 
-### /api/users/device-token • POST
+### /api/users/device-token/ • POST
 **Headers:**
 ```json
 {
@@ -143,7 +143,7 @@ python src/run.py
 }
 ```
 
-### /api/sections/track • POST
+### /api/sections/track/ • POST
 **Headers:**
 ```json
 {
@@ -171,7 +171,7 @@ python src/run.py
 }
 ```
 
-### /api/sections/untrack • POST
+### /api/sections/untrack/ • POST
 **Headers:**
 ```json
 {
@@ -199,7 +199,7 @@ python src/run.py
 }
 ```
 
-### /api/courses/search • POST
+### /api/courses/search/ • POST
 **Headers:**
 ```json
 {

--- a/src/app/coursegrab/controllers/initialize_session_controller.py
+++ b/src/app/coursegrab/controllers/initialize_session_controller.py
@@ -26,11 +26,7 @@ class InitializeSessionController(AppDevController):
             email, first_name, last_name = id_info["email"], id_info["given_name"], id_info["family_name"]
             created, user = users_dao.create_user(email, first_name, last_name)
 
-            return {
-                "session_token": user.session_token,
-                "session_expiration": user.session_expiration,
-                "update_token": user.update_token,
-            }
+            return user.serialize_session()
 
         except ValueError:
             raise Exception("Invalid token")

--- a/src/app/coursegrab/controllers/update_session_controller.py
+++ b/src/app/coursegrab/controllers/update_session_controller.py
@@ -12,8 +12,4 @@ class UpdateSessionController(AppDevController):
     def content(self, **kwargs):
         update_token = kwargs.get("bearer_token")
         user = users_dao.refresh_session(update_token)
-        return {
-            "session_token": user.session_token,
-            "session_expiration": user.session_expiration,
-            "update_token": user.update_token,
-        }
+        return user.serialize_session()

--- a/src/app/coursegrab/models/user.py
+++ b/src/app/coursegrab/models/user.py
@@ -43,13 +43,18 @@ class User(db.Model):
 
     def serialize(self):
         return {
+            **self.serialize_session(),
             "id": self.id,
             "device_token": self.device_token,
             "email": self.email,
             "first_name": self.first_name,
             "is_ios": self.is_ios,
             "last_name": self.last_name,
+        }
+
+    def serialize_session(self):
+        return {
             "session_token": self.session_token,
-            "session_expiration": round(self.session_expiration.timestamp()),
+            "session_expiration": str(round(self.session_expiration.timestamp())),
             "update_token": self.update_token,
         }


### PR DESCRIPTION
## Overview
The session_expiration field was returned incorrectly cause we weren't using a serialize() function which lead to the return values not matching the spec

## Changes Made
- Updated spec to include trailing slashes
- Added serialize function that returns session_expiration as unix string

## Test Coverage
Tested locally
