### PR TITLE
Fix issue with initialize session

### DIFF
--- a/src/app/coursegrab/controllers/initialize_session_controller.py
+++ b/src/app/coursegrab/controllers/initialize_session_controller.py
@@ -2,6 +2,7 @@ from os import environ
 from google.auth.transport import requests
 from google.oauth2 import id_token
 from . import *
+from app import db
 
 
 class InitializeSessionController(AppDevController):
@@ -25,6 +26,9 @@ class InitializeSessionController(AppDevController):
             # ID token is valid. Get the user's Google Account information.
             email, first_name, last_name = id_info["email"], id_info["given_name"], id_info["family_name"]
             created, user = users_dao.create_user(email, first_name, last_name)
+            if not created:
+                user.refresh_session()
+                db.session.commit()
 
             return user.serialize_session()
 


### PR DESCRIPTION
## Overview
If the user already existed, that user was returned as is without updating their credentials. This refreshes the credentials for existing users and saves it.

## Test Coverage
Deployed to server and had iOS test
