### PR TITLE
Clear section tracking history when new semester starts

### DIFF
--- a/src/app/coursegrab/dao/__init__.py
+++ b/src/app/coursegrab/dao/__init__.py
@@ -4,4 +4,4 @@ from app import db
 from app.coursegrab.models.course import Course
 from app.coursegrab.models.section import Section
 from app.coursegrab.models.semester import Semester
-from app.coursegrab.models.user import User
+from app.coursegrab.models.user import User, users_to_sections

--- a/src/app/coursegrab/dao/sections_dao.py
+++ b/src/app/coursegrab/dao/sections_dao.py
@@ -43,3 +43,5 @@ def get_users_tracking_section(catalog_num):
 
 def clear_table():
     Section.query.delete()
+    db.session.execute(users_to_sections.delete())
+    db.session.commit()


### PR DESCRIPTION

## Overview

Add logic to clear sections tracked by users when new semester starts.


## Test Coverage

Tested locally by scraping different semesters and checking data stored.

## Related PRs or Issues (delete if not applicable)

#49 

