### PR TITLE
Change response structure to avoid iOS struct mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ To run the app:
 python src/run.py
 ```
 
+## Running tests
+
+```
+pytest
+```
+
 ## Migrations
 
 ### Initialize migrations
@@ -133,28 +139,30 @@ python src/manage.py db upgrade
 ```json
 {
   "success": true,
-  "data": [
-    {
-      "catalog_num": 12401,
-      "course_num": 3110,
-      "instructors": ["Nate Foster (jnf27)"],
-      "is_tracking": true,
-      "section": "LEC 001 / TR 12:20pm - 1:10pm",
-      "status": "WAITLISTED",
-      "subject_code": "CS",
-      "title": "Data Structures and Functional Programming"
-    },
-    {
-      "catalog_num": 12403,
-      "course_num": 4090,
-      "instructors": [],
-      "is_tracking": true,
-      "section": "IND 606 / TBA",
-      "status": "OPEN",
-      "subject_code": "CEE",
-      "title": "CEE Undergraduate Research"
-    }
-  ],
+  "data": {
+    "sections": [
+      {
+        "catalog_num": 12401,
+        "course_num": 3110,
+        "instructors": ["Nate Foster (jnf27)"],
+        "is_tracking": true,
+        "section": "LEC 001 / TR 12:20pm - 1:10pm",
+        "status": "WAITLISTED",
+        "subject_code": "CS",
+        "title": "Data Structures and Functional Programming"
+      },
+      {
+        "catalog_num": 12403,
+        "course_num": 4090,
+        "instructors": [],
+        "is_tracking": true,
+        "section": "IND 606 / TBA",
+        "status": "OPEN",
+        "subject_code": "CEE",
+        "title": "CEE Undergraduate Research"
+      }
+    ]
+  },
   "timestamp": 1581335566
 }
 ```
@@ -313,19 +321,23 @@ python src/manage.py db upgrade
 {
   "success": true,
   "data": {
-    "subject_code": "CS",
-    "course_num": 3110,
-    "title": "Object-Oriented Programming and Data Structures",
-    "sections": [
+    "courses": [
       {
-        "catalog_num": 12401,
-        "course_num": 3110,
-        "instructors": ["Staff"],
-        "is_tracking": false,
-        "status": "OPEN",
-        "section": "DIS 212 / TR 12:20pm - 1:10pm",
         "subject_code": "CS",
-        "title": "Data Structures and Functional Programming"
+        "course_num": 3110,
+        "title": "Object-Oriented Programming and Data Structures",
+        "sections": [
+          {
+            "catalog_num": 12401,
+            "course_num": 3110,
+            "instructors": ["Staff"],
+            "is_tracking": false,
+            "status": "OPEN",
+            "section": "DIS 212 / TR 12:20pm - 1:10pm",
+            "subject_code": "CS",
+            "title": "Data Structures and Functional Programming"
+          }
+        ]
       }
     ]
   },

--- a/src/app/coursegrab/controllers/retrieve_tracking_controller.py
+++ b/src/app/coursegrab/controllers/retrieve_tracking_controller.py
@@ -12,4 +12,4 @@ class RetrieveTrackingController(AppDevController):
     def content(self, **kwargs):
         user = kwargs.get("user")
         sections = users_dao.get_tracked_sections(user.id)
-        return [section.serialize_with_user(user.id) for section in sections]
+        return {"sections": [section.serialize_with_user(user.id) for section in sections]}

--- a/src/app/coursegrab/controllers/search_course_controller.py
+++ b/src/app/coursegrab/controllers/search_course_controller.py
@@ -17,4 +17,4 @@ class SearchCourseController(AppDevController):
             raise Exception("Must provide query.")
 
         courses = courses_dao.search_courses(query)
-        return [course.serialize_with_user(user.id) for course in courses]
+        return {"courses": [course.serialize_with_user(user.id) for course in courses]}

--- a/src/tests/test_coursegrab.py
+++ b/src/tests/test_coursegrab.py
@@ -47,7 +47,7 @@ def test_retrieve_tracking_none(client, user):
     res = client_get(client, user, "/api/users/tracking/")
 
     assert res["success"]
-    assert res["data"] == []
+    assert res["data"]["sections"] == []
 
 
 def test_track_section(client, user):
@@ -63,7 +63,7 @@ def test_track_section(client, user):
     res = client_get(client, user, "/api/users/tracking/")
 
     assert res["success"]
-    assert res["data"] == [{**created_section.serialize(), "is_tracking": True}]
+    assert res["data"]["sections"] == [{**created_section.serialize(), "is_tracking": True}]
 
 
 def test_untrack_section(client, user):
@@ -81,7 +81,7 @@ def test_untrack_section(client, user):
     res = client_get(client, user, "/api/users/tracking/")
 
     assert res["success"]
-    assert res["data"] == []
+    assert res["data"]["sections"] == []
 
 
 def test_search_course(client, user):
@@ -94,7 +94,7 @@ def test_search_course(client, user):
     assert res["success"]
 
     created_course = courses_dao.get_course_by_subject_and_course_num("CS", 5430)
-    assert res["data"][0] == created_course.serialize_with_user(user.id)
+    assert res["data"]["courses"][0] == created_course.serialize_with_user(user.id)
 
 
 def test_update_device_token(client, user):


### PR DESCRIPTION
## Overview

There were instances where iOS ran into struct errors since `data` field was defined as array type for `/tracking` but object type for other routes. This commit unifies the response structure to help avoid similar issues. 


## Test Coverage

Pytest
