### PR TITLE
[Sessions][2/3] Handle expired device tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,16 @@ If we have access to the device's unique `device_token`, we can identify which d
 
 ### Clean-up Sessions
 
-[WIP] Handle invalid device_token errors
+1. One way to clean up the sessions table is to delete any sessions associated with invalid device tokens.
+   \
+   A user's device token becomes invalid if the user deletes the app from their device. Note that even if the user downloads the app again on the same device, the device token will not be identical. If we know that the device token is invalid, there is no need to keep the associated session because it will never be used again.
+   \
+   We can find out if a device token is expired by examining the response when we send out a push notification to that `device_token`.
 
-[WIP] Script to periodically clean up outdated sessions
+- [IOS] [APNS response status code](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW15) for invalid device token is `410`.
+- [ANDROID] [Firebase exception](https://firebase.google.com/docs/reference/admin/python/firebase_admin.messaging#unregisterederror) for invalid device token is `UnregisteredError`. NOTE: Device token is equivalent to 'registration token' in Firebase terminology.
+
+2. [WIP] Script to periodically clean up outdated sessions
 
 ## Endpoints
 

--- a/src/app/coursegrab/dao/sessions_dao.py
+++ b/src/app/coursegrab/dao/sessions_dao.py
@@ -51,3 +51,11 @@ def update_device_token(session_id, device_token):
     db.session.add(session)
     db.session.commit()
     return session
+
+
+# If there is an expired device_token, it is no longer in use (probably because the user
+# deleted the app). Therefore, we no longer need a session associated with this device_token.
+def delete_session_expired_device_tokens(tokens):
+    for token in tokens:
+        Session.query.filter(Session.device_token == token).delete()
+    db.session.commit()

--- a/src/tests/test_coursegrab.py
+++ b/src/tests/test_coursegrab.py
@@ -158,3 +158,13 @@ def test_create_session_no_device_token(client, session, user):
     sessions_dao.create_session(user.id, session.device_type)
 
     assert len(user.sessions) == 2
+
+
+def test_delete_session_expired_device_token(client, session, user):
+    new_session = sessions_dao.create_session(user.id, session.device_type)
+
+    assert Session.query.count() == 2
+
+    sessions_dao.delete_session_expired_device_tokens([session.device_token, new_session.device_token])
+
+    assert Session.query.count() == 0


### PR DESCRIPTION
## Overview

Delete associated user session if the device token is expired

## Changes Made

- Add a case handling 410 status code response for iOS
- Change FCM messaging from sending multicast to sending individual messages. `send_multicast` response structure doesn't provide a mapping of device token to response code so we can't identify which token corresponds to which response.
- Handle `UnregisteredError` exception handling for Android


## Test Coverage

Pytest


## Next Steps

Script to periodically clean up outdated sessions


## Related PRs or Issues

[1/3] Support multiple sessions #58 
