### PR TITLE
Change default notification to none

### DIFF
--- a/src/app/coursegrab/models/user.py
+++ b/src/app/coursegrab/models/user.py
@@ -1,5 +1,4 @@
 from app import db
-from ..utils.constants import EMAIL
 
 
 users_to_sections = db.Table(
@@ -24,7 +23,7 @@ class User(db.Model):
         self.email = kwargs.get("email")
         self.first_name = kwargs.get("first_name")
         self.last_name = kwargs.get("last_name")
-        self.notification = EMAIL  # Default notifications set to EMAIL
+        self.notification = None  # Default notifications set to None
 
     def serialize(self):
         return {


### PR DESCRIPTION
## Overview

Because web development is on hold for the semester, only mobile notifications will be supported. Since we don't have access to send notifications to users until a user deliberately allows push notifications, the default notification mode for a new user should be set to `None`.

## Related PRs or Issues (delete if not applicable)
#67 