### PR TITLE
Add Docker build & push and auto deployment workflow with Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,37 @@
-name: Docker Image CI
+name: Docker Build & Push and Deploy
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-
+    push:
+        branches: [master]
 jobs:
-
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+    path-context:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
+            - name: Login to DockerHub
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
+            - name: Get SHA
+              id: vars
+              run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+            - name: Docker build & push
+              uses: docker/build-push-action@v2
+              with:
+                  context: .
+                  file: ./Dockerfile
+                  push: true
+                  tags: ${{ secrets.DOCKER_USERNAME }}/coursegrab:${{ steps.vars.outputs.sha_short }}
+            - name: Remote ssh and deploy
+              uses: appleboy/ssh-action@master
+              with:
+                  host: ${{ secrets.SERVER_HOST }}
+                  username: ${{ secrets.SERVER_USERNAME }}
+                  key: ${{ secrets.SERVER_KEY }}
+                  script: |
+                      cd docker-compose
+                      docker stack deploy -c docker-compose.yml the-stack

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Docker Build & Push and Deploy
 
 on:
     push:
-        branches: [master]
+        branches: [release]
 jobs:
     path-context:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview
* Triggers on branch `release` (not `master`)
* Add Github Actions to build docker image, push to Docker Hub, and deploy on the coursegrab backend server on Digital Ocean (the SSH stuff is covered [here](https://github.com/appleboy/ssh-action))
* I've made the following secrets, and they are a mix of organization and repository secrets. You can edit them [here](https://github.com/cuappdev/coursegrab-backend/settings/secrets/actions
) (lmk if you need access)
* The reason why `SERVER_HOST` is the only repository secret is because each backend repository has a different server host


<img width="519" alt="Screen Shot 2021-02-04 at 9 08 41 PM" src="https://user-images.githubusercontent.com/13739525/106980052-82c3ee80-672d-11eb-9c81-71127a8468d2.png">



## Next Steps
Need to push to master to see if this works lol gotta wing this