### PR TITLE
Docker prune all old tags on server in auto deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,3 +36,4 @@ jobs:
                       export IMAGE_TAG=${{ steps.vars.outputs.sha_short }}
                       cd docker-compose
                       docker stack deploy -c docker-compose.yml the-stack
+                      docker system prune -a


### PR DESCRIPTION
this cleans up all old images that are just sitting on the server
cleans up many GBs at a time you'd be surprised

if this doesn't work i'll figure something out