### PR TITLE
Update auto deployment workflow to include rm stack and system prune

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,4 +35,10 @@ jobs:
                   script: |
                       export IMAGE_TAG=${{ steps.vars.outputs.sha_short }}
                       cd docker-compose
+                      docker stack rm the-stack
+                      sleep 20s
+                      sudo systemctl stop nginx
+                      sudo systemctl restart nginx
                       docker stack deploy -c docker-compose.yml the-stack
+                      docker system prune -a
+                      yes | docker system prune -a

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,5 +40,4 @@ jobs:
                       sudo systemctl stop nginx
                       sudo systemctl restart nginx
                       docker stack deploy -c docker-compose.yml the-stack
-                      docker system prune -a
                       yes | docker system prune -a


### PR DESCRIPTION
1. `docker stack rm the-stack` just makes sure we're not re-using old containers
2. `sleep 20s` is so that we give the stack some time to be removed
3. `stop nginx` and `restart nginx` is for `https` 
4. `stack deploy -c` is the standard deploy command
5. `docker system prune -a` makes sure we don't keep the old images from clogging up our memory
6. we pipe in `yes |` because the prune command takes input for confirmation :) 