### PR TITLE
Fix scraping

### DIFF
--- a/src/app/coursegrab/utils/scraper.py
+++ b/src/app/coursegrab/utils/scraper.py
@@ -115,7 +115,7 @@ def scrape_classes():
                         instructors.append(name)
                 instructor_str = ",".join(instructors) if instructors else None
 
-                open_status = section_tag.find_all("li", class_="open-status")[0].contents[0].contents[0]["class"][-1]
+                open_status = section_tag.find_all("li", class_="open-status")[0].find_all("span")[0].contents[0]["class"][-1]
                 status = INVALID
                 if "open-status-open" in open_status:
                     status = OPEN
@@ -152,7 +152,7 @@ def update_all_statuses():
                 catalog_tag = section_tag.find_all("strong", class_="tooltip-iws")[0]
                 catalog_num = int(catalog_tag.getText().strip())
 
-                open_status = section_tag.find_all("li", class_="open-status")[0].contents[0].contents[0]["class"][-1]
+                open_status = section_tag.find_all("li", class_="open-status")[0].find_all("span")[0].contents[0]["class"][-1]
                 status = INVALID
                 if "open-status-open" in open_status:
                     status = OPEN

--- a/src/app/coursegrab/utils/scraper.py
+++ b/src/app/coursegrab/utils/scraper.py
@@ -115,7 +115,7 @@ def scrape_classes():
                         instructors.append(name)
                 instructor_str = ",".join(instructors) if instructors else None
 
-                open_status = section_tag.find_all("li", class_="open-status")[0].find_all("span")[0].contents[0]["class"][-1]
+                open_status = section_tag.find_all("li", class_="open-status")[0].contents[0].contents[0]["class"][-1]
                 status = INVALID
                 if "open-status-open" in open_status:
                     status = OPEN
@@ -152,7 +152,7 @@ def update_all_statuses():
                 catalog_tag = section_tag.find_all("strong", class_="tooltip-iws")[0]
                 catalog_num = int(catalog_tag.getText().strip())
 
-                open_status = section_tag.find_all("li", class_="open-status")[0].find_all("span")[0].contents[0]["class"][-1]
+                open_status = section_tag.find_all("li", class_="open-status")[0].contents[0].contents[0]["class"][-1]
                 status = INVALID
                 if "open-status-open" in open_status:
                     status = OPEN


### PR DESCRIPTION
## Overview

Fixed classes scraping so it works normally again


## Changes Made

As brought up in #communications channel, the scraper keeps restarting itself due to an exception when parsing the HTML section tags to see if a course was open or not. To fix, I added a find_all("span") to get the correct tags after the first find_all("li")


## Test Coverage
Tested starting the server manually again and the updating course statuses stopped restarting like every second. Classes also showed up normally in search again
